### PR TITLE
Add request listeners

### DIFF
--- a/lib/google_r/version.rb
+++ b/lib/google_r/version.rb
@@ -1,3 +1,3 @@
 class GoogleR
-  VERSION = "0.1.5"
+  VERSION = "0.1.6"
 end

--- a/spec/fixtures/calendar_list.json
+++ b/spec/fixtures/calendar_list.json
@@ -1,0 +1,22 @@
+{
+ "kind": "calendar#calendarList",
+ "etag": "\"p33g9te72ti2d00g\"",
+ "nextSyncToken": "foo=",
+ "items": [
+  {
+
+   "kind": "calendar#calendarListEntry",
+   "etag": "\"14779102593600\"",
+   "id": "foo",
+   "summary": "Base Tasks",
+   "description": "Tasks from Base CRM",
+   "timeZone": "+02:00 Amsterdam",
+   "colorId": "18",
+   "backgroundColor": "#b99aff",
+   "foregroundColor": "#000000",
+   "selected": true,
+   "accessRole": "owner",
+   "defaultReminders": [
+   ]
+}
+]}

--- a/spec/google_api_spec.rb
+++ b/spec/google_api_spec.rb
@@ -87,4 +87,33 @@ describe GoogleR do
       end
     end
   end
+
+  context "requests listeners" do
+    let(:event_handler) { double }
+
+    before do
+      google_calendars = File.read('spec/fixtures/calendar_list.json');
+      allow_any_instance_of(Faraday::Connection).to receive(:send).and_return(
+        mock(:body => google_calendars,
+             :status => 200,
+             :headers => {"Content-Type" => "json"})
+      )
+    end
+
+    it "adds listeners" do
+      expect((api.subscribe_request_listener(:get) { |event| event }).size).to eq(1)
+    end
+
+    it  "calls block on fetch" do
+      expect(event_handler).to receive(:handle)
+      api.subscribe_request_listener(:get) { |event| event_handler.handle(event) }
+
+      api.calendars
+    end
+
+    it "doesn't try to call when listener is not subscribed" do
+      expect{ api.calendars }.not_to raise_error(NoMethodError)
+    end
+
+  end
 end


### PR DESCRIPTION
This PR adds listener logic to GoogleR object. A listener is called
before every request. No data is passed to listener.