### PR TITLE
Use available logger when performing requests

### DIFF
--- a/lib/google_r.rb
+++ b/lib/google_r.rb
@@ -159,7 +159,7 @@ class GoogleR
         req.headers[header] = value
       end
       req.body = body
-      puts "#{http_method} #{url}/#{path}"
+      self.logger.debug "#{http_method} #{url}/#{path}"
     end
   end
 


### PR DESCRIPTION
Things were going to `stdout`