### PR TITLE
Gracefuly handle a case when 'created' or 'updated' fields are missing on Event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 0.1.8
++ [enhancement] Gracefuly handle cases where Event is lacking 'created' aor 'updated' field.
+
 # 0.1.7
 + [enhancement] Send also empty 'date' field for Event's start and end fields, to be able to update all day events (see https://stackoverflow.com/a/35658479/815183)
 

--- a/lib/google_r/event.rb
+++ b/lib/google_r/event.rb
@@ -58,8 +58,8 @@ class GoogleR::Event
         event.end_time_zone = json["end"]["timeZone"]
       end
 
-      event.updated = Time.parse(json["updated"])
-      event.created = Time.parse(json["created"])
+      event.updated = Time.parse(json["updated"]) if json['updated']
+      event.created = Time.parse(json["created"]) if json['created']
       event
     else
       raise "Not implemented:\n#{json.inspect}"

--- a/lib/google_r/version.rb
+++ b/lib/google_r/version.rb
@@ -1,3 +1,3 @@
 class GoogleR
-  VERSION = "0.1.7"
+  VERSION = "0.1.8"
 end


### PR DESCRIPTION
Documentation of API is a bit vague about them being required fields in response, and we did get errors for that case, so... this.